### PR TITLE
rename the zip field to postal_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ origin = Shippex.Address.new(%{
   address_line_2: nil,
   city: "Austin",
   state: "TX",
-  zip: "78703"
+  postal_code: "78703"
 })
 
 destination = Shippex.Address.new(%{
@@ -44,7 +44,7 @@ destination = Shippex.Address.new(%{
   address_line_2: nil,
   city: "Plano",
   state: "TX",
-  zip: "75074",
+  postal_code: "75074",
   country: "US" # optional
 })
 

--- a/lib/shippex.ex
+++ b/lib/shippex.ex
@@ -19,7 +19,7 @@ defmodule Shippex do
               address: "1234 Foo St",
               city: "Foo",
               state: "TX",
-              zip: "78999"
+              postal_code: "78999"
             }
           ],
           usps: [
@@ -37,7 +37,7 @@ defmodule Shippex do
         address_line_2: nil,
         city: "Austin",
         state: "TX",
-        zip: "78703"
+        postal_code: "78703"
       })
 
       destination = Shippex.Address.new(%{
@@ -47,7 +47,7 @@ defmodule Shippex do
         address_line_2: nil,
         city: "Plano",
         state: "TX",
-        zip: "75074"
+        postal_code: "75074"
       })
 
   ## Create a package
@@ -283,7 +283,7 @@ defmodule Shippex do
         address_line_2: nil,
         city: "Austin",
         state: "TX",
-        zip: "78703"
+        postal_code: "78703"
       })
 
       case Shippex.validate_address(address) do

--- a/lib/shippex/address.ex
+++ b/lib/shippex/address.ex
@@ -5,10 +5,10 @@ defmodule Shippex.Address do
   """
 
   @enforce_keys ~w(first_name last_name name phone address address_line_2 city
-                   state zip country)a
+                   state postal_code country)a
 
   defstruct ~w(first_name last_name name company_name phone address
-               address_line_2 city state zip country)a
+               address_line_2 city state postal_code country)a
 
   @type t() :: %__MODULE__{
           first_name: nil | String.t(),
@@ -20,7 +20,7 @@ defmodule Shippex.Address do
           address_line_2: nil | String.t(),
           city: String.t(),
           state: String.t(),
-          zip: String.t(),
+          postal_code: String.t(),
           country: ISO.country_code()
         }
 
@@ -47,7 +47,7 @@ defmodule Shippex.Address do
         address_line_2: nil,
         city: "Austin",
         state: "TX",
-        zip: "78703"
+        postal_code: "78703"
       })
   """
   @spec new(map()) :: {:ok, t()} | {:error, String.t()}
@@ -118,7 +118,7 @@ defmodule Shippex.Address do
       address_line_2: params["address_line_2"],
       city: params["city"],
       state: state,
-      zip: String.trim(params["zip"] || ""),
+      postal_code: String.trim(params["postal_code"] || ""),
       country: country
     }
 
@@ -187,7 +187,7 @@ defmodule Shippex.Address do
       ...>   address_line_2: nil,
       ...>   city: "Austin",
       ...>   state: "US-TX",
-      ...>   zip: "78703",
+      ...>   postal_code: "78703",
       ...>   country: "US"
       ...>  })
       iex> Address.state_without_country(address)

--- a/lib/shippex/carrier/ups.ex
+++ b/lib/shippex/carrier/ups.ex
@@ -183,7 +183,7 @@ defmodule Shippex.Carrier.UPS do
           AddressLine: address.address,
           PoliticalDivision2: address.city,
           PoliticalDivision1: state,
-          PostcodePrimaryLow: address.zip,
+          PostcodePrimaryLow: address.postal_code,
           CountryCode: address.country
         }
       }
@@ -218,7 +218,7 @@ defmodule Shippex.Carrier.UPS do
               "address_line_2" => address.address_line_2,
               "city" => candidate["PoliticalDivision2"],
               "state" => candidate["PoliticalDivision1"],
-              "zip" => candidate["PostcodePrimaryLow"],
+              "postal_code" => candidate["PostcodePrimaryLow"],
               "country" => candidate["CountryCode"]
             })
           end)
@@ -331,7 +331,7 @@ defmodule Shippex.Carrier.UPS do
         AddressLine: Address.address_line_list(address),
         City: address.city,
         StateProvinceCode: state,
-        PostalCode: String.replace(address.zip, ~r/\s+/, ""),
+        PostalCode: String.replace(address.postal_code, ~r/\s+/, ""),
         CountryCode: address.country
       }
     }
@@ -348,7 +348,7 @@ defmodule Shippex.Carrier.UPS do
         "address_line_2" => config.shipper[:address_line_2],
         "city" => config.shipper.city,
         "state" => config.shipper.state,
-        "zip" => config.shipper.zip,
+        "postal_code" => config.shipper.postal_code,
         "country" => config.shipper[:country]
       })
 

--- a/lib/shippex/carrier/usps.ex
+++ b/lib/shippex/carrier/usps.ex
@@ -380,7 +380,7 @@ defmodule Shippex.Carrier.USPS do
           address_line_2: ~x"./Address1//text()"s,
           city: ~x"./City//text()"s,
           state: ~x"./State//text()"s,
-          zip: ~x"./Zip5//text()"s
+          postal_code: ~x"./Zip5//text()"s
         )
         |> Enum.map(fn candidate ->
           candidate

--- a/lib/shippex/carrier/usps/templates/address.eex
+++ b/lib/shippex/carrier/usps/templates/address.eex
@@ -19,12 +19,12 @@
 <%= if international?(@shipment) and @address == :to do %>
   <<%= prefix %>Province><%= address.state %></<%= prefix %>Province>
   <<%= prefix %>Country><%= country(address) %></<%= prefix %>Country>
-  <<%= prefix %>PostalCode><%= address.zip %></<%= prefix %>PostalCode>
+  <<%= prefix %>PostalCode><%= address.postal_code %></<%= prefix %>PostalCode>
   <<%= prefix %>POBoxFlag>N</<%= prefix %>POBoxFlag>
   <<%= prefix %>Phone><%= address.phone %></<%= prefix %>Phone>
 <% else %>
   <<%= prefix %>State><%= state_without_country(address) %></<%= prefix %>State>
-  <<%= prefix %>Zip5><%= address.zip %></<%= prefix %>Zip5>
+  <<%= prefix %>Zip5><%= address.postal_code %></<%= prefix %>Zip5>
   <<%= prefix %>Zip4></<%= prefix %>Zip4>
   <% phone = (address.phone || "") |> String.replace(~r/^\+1/, "") |> String.replace(~r/\D+/, "") %>
   <<%= prefix %>Phone><%= phone %></<%= prefix %>Phone>

--- a/lib/shippex/carrier/usps/templates/rate.eex
+++ b/lib/shippex/carrier/usps/templates/rate.eex
@@ -19,7 +19,7 @@
       <Height><%= package.height %></Height>
       <Girth></Girth>
 
-      <OriginZip><%= @shipment.from.zip %></OriginZip>
+      <OriginZip><%= @shipment.from.postal_code %></OriginZip>
 
       <%= if package.insurance do %>
         <ExtraServices>
@@ -34,8 +34,8 @@
 
     <Package ID="0">
       <Service><%= Service.service_code(@service) %></Service>
-      <ZipOrigination><%= @shipment.from.zip %></ZipOrigination>
-      <ZipDestination><%= @shipment.to.zip %></ZipDestination>
+      <ZipOrigination><%= @shipment.from.postal_code %></ZipOrigination>
+      <ZipDestination><%= @shipment.to.postal_code %></ZipDestination>
       <Pounds>0</Pounds>
       <Ounces><%= weight_in_ounces(@shipment.package.weight) %></Ounces>
       <Container><%= container(@shipment) %></Container>

--- a/lib/shippex/carrier/usps/templates/validate_address.eex
+++ b/lib/shippex/carrier/usps/templates/validate_address.eex
@@ -6,7 +6,7 @@
     <Address2><%= @address.address %></Address2>
     <City><%= @address.city %></City>
     <State><%= @address.state %></State>
-    <Zip5><%= @address.zip %></Zip5>
+    <Zip5><%= @address.postal_code %></Zip5>
     <Zip4></Zip4>
   </Address>
 </AddressValidateRequest>

--- a/test/shippex/address_test.exs
+++ b/test/shippex/address_test.exs
@@ -10,7 +10,7 @@ defmodule Shippex.AddressTest do
         "address" => "9999 Hobby Ln",
         "city" => "Austin",
         "state" => "Texas",
-        "zip" => "78703",
+        "postal_code" => "78703",
         "country" => "US"
       })
 
@@ -25,7 +25,7 @@ defmodule Shippex.AddressTest do
         "address" => "9999 Hobby Ln",
         "city" => "Austin",
         "state" => "Texas",
-        "zip" => "78703",
+        "postal_code" => "78703",
         "country" => "United States"
       })
 
@@ -42,7 +42,7 @@ defmodule Shippex.AddressTest do
         "address" => [address_line_1, address_line_2],
         "city" => "Austin",
         "state" => "Texas",
-        "zip" => "78703"
+        "postal_code" => "78703"
       })
 
     assert address.address == address_line_1
@@ -57,7 +57,7 @@ defmodule Shippex.AddressTest do
         "city" => "Singapore",
         "state" => "SG-01",
         "country" => "SG",
-        "zip" => "310260"
+        "postal_code" => "310260"
       })
 
     # Valid country, invalid state
@@ -68,7 +68,7 @@ defmodule Shippex.AddressTest do
         "city" => "Singapore",
         "state" => "SG-ABCABC",
         "country" => "SG",
-        "zip" => "310260"
+        "postal_code" => "310260"
       })
 
     assert error =~ ~r/invalid subdivision/i
@@ -81,7 +81,7 @@ defmodule Shippex.AddressTest do
         "city" => "Singapore",
         "state" => "SG-01",
         "country" => "SGG",
-        "zip" => "310260"
+        "postal_code" => "310260"
       })
 
     assert error =~ ~r/invalid country/i

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,7 +17,7 @@ defmodule Helper do
       address_line_2: nil,
       city: "Austin",
       state: "US-TX",
-      zip: "78722"
+      postal_code: "78722"
     })
   end
 
@@ -32,7 +32,7 @@ defmodule Helper do
       address_line_2: nil,
       city: "Wappapello",
       state: "US-MO",
-      zip: "63966"
+      postal_code: "63966"
     })
   end
 
@@ -44,7 +44,7 @@ defmodule Helper do
       address: "4575 Clancy Loranger Way",
       city: "Vancouver",
       state: "CA-BC",
-      zip: "V5Y 2M4",
+      postal_code: "V5Y 2M4",
       country: "CA"
     })
   end
@@ -57,7 +57,7 @@ defmodule Helper do
       address: "Ferrol 4",
       city: "Ciudad de México",
       state: "MX-CMX",
-      zip: "03100",
+      postal_code: "03100",
       country: "MX"
     })
   end
@@ -72,7 +72,7 @@ defmodule Helper do
         _ -> nil
       end
 
-    {city, zip} = city_zip(country)
+    {city, postal_code} = city_postal_code(country)
 
     Shippex.Address.new!(%{
       first_name: "Some",
@@ -81,22 +81,22 @@ defmodule Helper do
       address: "4575 Random Address Rd",
       city: city,
       state: state,
-      zip: zip,
+      postal_code: postal_code,
       country: country
     })
   end
 
   def destination(%Shippex.Address{} = address), do: address
 
-  defp city_zip("AS"), do: {"Pago Pago", "96799"}
-  defp city_zip("GU"), do: {"Hagatna", "96910"}
-  defp city_zip("FM"), do: {"Chuuk", "96942"}
-  defp city_zip("MH"), do: {"Majuro", "96970"}
-  defp city_zip("MP"), do: {"Saipan", "96950"}
-  defp city_zip("PR"), do: {"San Juan", "00921"}
-  defp city_zip("PW"), do: {"Ngerulmud", "96939"}
-  defp city_zip("VI"), do: {"Cruz Bay", "00830"}
-  defp city_zip(_), do: {"City", "00000"}
+  defp city_postal_code("AS"), do: {"Pago Pago", "96799"}
+  defp city_postal_code("GU"), do: {"Hagatna", "96910"}
+  defp city_postal_code("FM"), do: {"Chuuk", "96942"}
+  defp city_postal_code("MH"), do: {"Majuro", "96970"}
+  defp city_postal_code("MP"), do: {"Saipan", "96950"}
+  defp city_postal_code("PR"), do: {"San Juan", "00921"}
+  defp city_postal_code("PW"), do: {"Ngerulmud", "96939"}
+  defp city_postal_code("VI"), do: {"Cruz Bay", "00830"}
+  defp city_postal_code(_), do: {"City", "00000"}
 
   def package(insurance \\ nil) do
     Shippex.Package.new(%{

--- a/test/ups/address_test.exs
+++ b/test/ups/address_test.exs
@@ -15,7 +15,7 @@ defmodule Shippex.UPS.AddressTest do
         "address_line_2" => "Suite 101",
         "city" => "Los Angeles",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     assert valid_address.address_line_2 == "Suite 101"
@@ -35,7 +35,7 @@ defmodule Shippex.UPS.AddressTest do
         "address_line_2" => "Suite 101",
         "city" => "Los Angeles",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     {:ok, candidates} = Shippex.validate_address(ambiguous_address, carrier: :ups)
@@ -46,7 +46,7 @@ defmodule Shippex.UPS.AddressTest do
         "address" => "9999 Wat Wat",
         "city" => "San Francisco",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     {:error, _} = Shippex.validate_address(invalid_address, carrier: :ups)

--- a/test/usps/address_test.exs
+++ b/test/usps/address_test.exs
@@ -12,7 +12,7 @@ defmodule Shippex.USPS.AddressTest do
         "address" => "404 S Figueroa St",
         "city" => "Los Angeles",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     {:ok, candidates} = Shippex.validate_address(valid_address, carrier: :usps)
@@ -39,7 +39,7 @@ defmodule Shippex.USPS.AddressTest do
         "address_line_2" => "Suite 101",
         "city" => "Los Angeles",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     assert valid_address.address_line_2 == "Suite 101"
@@ -62,7 +62,7 @@ defmodule Shippex.USPS.AddressTest do
         "address" => "9999 Wat Wat",
         "city" => "San Francisco",
         "state" => "CA",
-        "zip" => "90071"
+        "postal_code" => "90071"
       })
 
     {:error, _} = Shippex.validate_address(invalid_address, carrier: :usps)


### PR DESCRIPTION
This PR will rename the `zip` field to `postal_code` as we discussed, it breaks compatibility so probably best to release with a major version bump. 